### PR TITLE
Softer auto moderation

### DIFF
--- a/packages/ui/banned-delegates.json
+++ b/packages/ui/banned-delegates.json
@@ -1,1 +1,0 @@
-[{ "address": "0x40D579E6778b9BD453d8fC7ED055309a6f7Ea516" }]

--- a/packages/ui/constants.ts
+++ b/packages/ui/constants.ts
@@ -53,3 +53,13 @@ export const PUB_FORUM_URL = "https://community.taiko.xyz/";
 export const PUB_WALLET_ICON = "https://avatars.githubusercontent.com/u/37784886";
 
 export const PUB_TWITTER_ACCOUNT = "taikoxyz";
+
+export const GlinConfig = {
+  allLanguages: true,
+  allowObfuscatedMatch: false,
+  fuzzyToleranceLevel: 0.7,
+  wordBoundaries: true,
+  severityLevels: true,
+  customWords: ["pidarasi", "PIDARASI"],
+  logProfanity: false,
+};

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -40,6 +40,7 @@
     "classnames": "^2.5.1",
     "dayjs": "^1.11.10",
     "dompurify": "^3.0.11",
+    "glin-profanity": "^2.0.0",
     "graphql": "^16.11.0",
     "libsodium-wrappers": "^0.7.13",
     "multiformats": "^13.1.1",

--- a/packages/ui/plugins/delegates/components/DelegateMemberList.tsx
+++ b/packages/ui/plugins/delegates/components/DelegateMemberList.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { CardEmptyState, DataList } from "@aragon/ods";
 import { DelegateListItem } from "./DelegateListItem";
 import { equalAddresses } from "@/utils/evm";
@@ -6,8 +6,6 @@ import { useDelegates } from "../hooks/useDelegates";
 import { useTokenVotes } from "../../../hooks/useTokenVotes";
 import { useAccount } from "wagmi";
 import VerifiedDelegates from "../../../verified-delegates.json";
-import BannedDelegates from "../../../banned-delegates.json";
-
 import { PleaseWaitSpinner } from "@/components/please-wait";
 
 interface IDelegateMemberListProps {
@@ -20,15 +18,10 @@ export const DelegateMemberList: React.FC<IDelegateMemberListProps> = ({ verifie
   //   const [activeSort, setActiveSort] = useState<string>();
   const { delegates: fetchedDelegates, status: loadingStatus } = useDelegates();
   const { delegatesTo } = useTokenVotes(address);
-  const delegates = (fetchedDelegates || [])
-    .filter((item) => {
-      if (!verifiedOnly) return true;
-      return BannedDelegates.findIndex((d) => equalAddresses(d.address, item)) < 0;
-    })
-    .filter((item) => {
-      if (!verifiedOnly) return true;
-      return VerifiedDelegates.findIndex((d) => equalAddresses(d.address, item)) >= 0;
-    });
+  const delegates = (fetchedDelegates || []).filter((item) => {
+    if (!verifiedOnly) return true;
+    return VerifiedDelegates.findIndex((d) => equalAddresses(d.address, item)) >= 0;
+  });
 
   if (loadingStatus === "pending" && !delegates?.length) {
     return <PleaseWaitSpinner fullMessage="Please wait, loading candidates" />;

--- a/packages/ui/plugins/delegates/pages/delegate-profile.tsx
+++ b/packages/ui/plugins/delegates/pages/delegate-profile.tsx
@@ -4,19 +4,35 @@ import { DelegationStatement } from "../components/DelegationStatement";
 import { HeaderMember } from "../components/HeaderMember";
 import { useDelegateAnnounce } from "../hooks/useDelegateAnnounce";
 import { formatHexString } from "@/utils/evm";
+import { GlinConfig } from "@/constants";
+import { useEffect } from "react";
+import { useProfanityChecker } from "glin-profanity";
 
 export const DelegateProfile = ({ address }: { address: Address }) => {
   const { announce, isLoading } = useDelegateAnnounce(address);
+  console.log({ announce });
+  const { result, checkText } = useProfanityChecker(GlinConfig);
 
+  console.log({ result });
+  useEffect(() => {
+    if (!announce) return;
+    checkText(`${announce.identifier}\n${announce.bio}\n${announce.message}`);
+  }, [announce]);
   return (
     <div className="flex flex-col items-center">
-      <HeaderMember address={address} name={announce?.identifier || formatHexString(address)} bio={announce?.bio} />
+      {(!result || !result.containsProfanity) && (
+        <HeaderMember address={address} name={announce?.identifier || formatHexString(address)} bio={announce?.bio} />
+      )}
       <div className="flex w-full max-w-screen-xl flex-col gap-x-12 gap-y-12 px-4 py-6 md:flex-row md:px-16 md:pb-20">
         {/* Main section */}
         <div className="flex flex-col gap-y-12 md:w-[63%] md:gap-y-20">
           {/* Delegation Statement */}
           <div className="flex w-full flex-col gap-y-6 overflow-auto">
-            <DelegationStatement message={announce?.message} />
+            {result && result.containsProfanity ? (
+              "PROFILE MODERATED DUE TO PROFANITY"
+            ) : (
+              <DelegationStatement message={announce?.message} />
+            )}
           </div>
         </div>
         {/* Aside */}

--- a/packages/ui/plugins/delegates/pages/delegate-profile.tsx
+++ b/packages/ui/plugins/delegates/pages/delegate-profile.tsx
@@ -6,22 +6,20 @@ import { useDelegateAnnounce } from "../hooks/useDelegateAnnounce";
 import { formatHexString } from "@/utils/evm";
 import { GlinConfig } from "@/constants";
 import { useEffect } from "react";
-import { useProfanityChecker } from "glin-profanity";
+import { useProfanityChecker } from 'glin-profanity';
 
 export const DelegateProfile = ({ address }: { address: Address }) => {
-  const { announce, isLoading } = useDelegateAnnounce(address);
-  console.log({ announce });
+  const { announce } = useDelegateAnnounce(address);
   const { result, checkText } = useProfanityChecker(GlinConfig);
 
-  console.log({ result });
   useEffect(() => {
-    if (!announce) return;
-    checkText(`${announce.identifier}\n${announce.bio}\n${announce.message}`);
-  }, [announce]);
+    if (!announce) return 
+    checkText(`${announce.identifier}\n${announce.bio}\n${announce.message}`)
+  }, [announce])
   return (
     <div className="flex flex-col items-center">
       {(!result || !result.containsProfanity) && (
-        <HeaderMember address={address} name={announce?.identifier || formatHexString(address)} bio={announce?.bio} />
+              <HeaderMember address={address} name={announce?.identifier || formatHexString(address)} bio={announce?.bio} />
       )}
       <div className="flex w-full max-w-screen-xl flex-col gap-x-12 gap-y-12 px-4 py-6 md:flex-row md:px-16 md:pb-20">
         {/* Main section */}


### PR DESCRIPTION
Instead of banning delegates on a per-wallet basis, implements a soft moderation that hides the profile information containing forbidden words.

The base list of banned words, with multi-lingual support, is offered by [Glin Profanity](https://github.com/GLINCKER/glin-profanity)