### PR TITLE
Fix: floor voting power display by truncating decimals

### DIFF
--- a/packages/ui/plugins/delegates/components/DelegateListItem.tsx
+++ b/packages/ui/plugins/delegates/components/DelegateListItem.tsx
@@ -86,7 +86,7 @@ export const DelegateListItem: React.FC<IDelegateListItemProps> = (props) => {
           <div className="flex h-12 flex-col gap-y-2">
             <p className="text-sm md:text-base">
               <span className="text-neutral-500">Voting Power: </span>
-              {formatEther(votingPower || BigInt(0))}
+              {formatEther(votingPower || 0n).split(".")[0]}
             </p>
           </div>
         </If>

--- a/packages/ui/plugins/delegates/components/HeaderMember.tsx
+++ b/packages/ui/plugins/delegates/components/HeaderMember.tsx
@@ -57,7 +57,7 @@ export const HeaderMember: React.FC<IHeaderMemberProps> = (props) => {
                 {/* Voting power */}
                 <div className="flex flex-col gap-y-1 leading-tight">
                   <div className="flex items-baseline gap-x-1">
-                    <span className="text-2xl text-neutral-800">{formatEther(votingPower || BigInt(0))}</span>
+                    <span className="text-2xl text-neutral-800">{formatEther(votingPower || 0n).split(".")[0]}</span>
                     <span className="text-base text-neutral-500">{PUB_TOKEN_SYMBOL}</span>
                   </div>
                   <span className="text-sm text-neutral-500">Voting power</span>


### PR DESCRIPTION
Before
![image-11111](https://github.com/user-attachments/assets/cbead1e9-28f2-4d9c-8d6e-62c3081991f4)


After
<img width="287" alt="Screen Shot 2025-05-29 at 12 50 20 AM" src="https://github.com/user-attachments/assets/e897db87-f2db-43bf-8eb4-2925f9f2f32f" />
