### PR TITLE
fix(dao-ui): remove duplicate wagmi config causing React initialization error

### DIFF
--- a/packages/ui/src/components/WalletContainer.tsx
+++ b/packages/ui/src/components/WalletContainer.tsx
@@ -1,26 +1,15 @@
-import { PUB_CHAIN, PUB_CHAIN_NAME, PUB_WEB3_ENDPOINT } from "@/constants";
+import { PUB_CHAIN, PUB_CHAIN_NAME } from "@/constants";
+import { config } from "@/context/Web3Modal";
 import { formatHexString } from "@/utils/evm";
 import { MemberAvatar } from "@aragon/ods";
 import { useWeb3Modal } from "@web3modal/wagmi/react";
 import classNames from "classnames";
 import { useEffect } from "react";
-import { createClient, http } from "viem";
 import { normalize } from "viem/ens";
-import { createConfig, useAccount, useEnsAvatar, useEnsName, useSwitchChain } from "wagmi";
+import { useAccount, useEnsAvatar, useEnsName, useSwitchChain } from "wagmi";
 import { holesky, mainnet } from "wagmi/chains";
 
 const activeChain = PUB_CHAIN_NAME === "holesky" ? holesky : mainnet;
-
-const config = createConfig({
-  chains: [mainnet, holesky],
-  ssr: true,
-  client({ chain }) {
-    return createClient({
-      chain,
-      transport: http(PUB_WEB3_ENDPOINT, { batch: true }),
-    });
-  },
-});
 
 // TODO: update with ODS wallet module - [https://linear.app/aragon/issue/RD-198/create-ods-walletmodule]
 const WalletContainer = () => {


### PR DESCRIPTION
- Removed duplicate createConfig in WalletContainer.tsx
- Now uses shared config from Web3Modal.tsx
- Fixes 'Cannot access R before initialization' error in production
- Resolves WalletConnect connection issues caused by conflicting configs

This fixes the issue where security council members cannot approve proposals due to React framework initialization errors in the production build.