### PR TITLE
fix(dao-ui): proxy pinata uploads

### DIFF
--- a/packages/ui/.env.example
+++ b/packages/ui/.env.example
@@ -26,7 +26,9 @@ NEXT_PUBLIC_ALCHEMY_API_KEY="ALCHEMY KEY"
 NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID="YOUR WALLET CONNECT PROJECT ID"
 
 NEXT_PUBLIC_IPFS_ENDPOINTS="https://domain1/api,https://domain2/api/v0"
-NEXT_PUBLIC_PINATA_JWT="..."
+# Server-only secret (NO NEXT_PUBLIC_ prefix): used by /api/pin to pin
+# proposal metadata. Must never be inlined into the client bundle.
+PINATA_JWT="..."
 
 NEXT_PUBLIC_ETHERSCAN_API_KEY="OPTIONAL: ETHERSCAN API"
 

--- a/packages/ui/src/constants.ts
+++ b/packages/ui/src/constants.ts
@@ -47,7 +47,8 @@ export const PUB_ETHERSCAN_API_KEY = process.env.NEXT_PUBLIC_ETHERSCAN_API_KEY ?
 export const PUB_WALLET_CONNECT_PROJECT_ID = process.env.NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID ?? "";
 
 export const PUB_IPFS_ENDPOINTS = process.env.NEXT_PUBLIC_IPFS_ENDPOINTS ?? "";
-export const PUB_PINATA_JWT = process.env.NEXT_PUBLIC_PINATA_JWT ?? "";
+// NOTE: The Pinata credential is intentionally NOT exposed here. It is a
+// server-only secret (process.env.PINATA_JWT) read by src/pages/api/pin.ts.
 
 // Private multisig
 export const DETERMINISTIC_EMERGENCY_PAYLOAD =

--- a/packages/ui/src/pages/api/pin.ts
+++ b/packages/ui/src/pages/api/pin.ts
@@ -1,0 +1,116 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+const PINATA_PIN_FILE_URL = "https://api.pinata.cloud/pinning/pinFileToIPFS";
+const UPLOAD_FILE_NAME = "taiko.json";
+
+// Largest real proposal-metadata pin ever observed on the project's Pinata
+// account is ~663 KB (across 579 pins, Dec 2024–May 2026). All upload flows
+// (multisig / emergency-multisig public+private / delegate announcements)
+// are text-only metadata — no inline images/base64. 2 MB gives ~3x headroom
+// for any future large proposal while still blocking multi-MB/GB abuse.
+const MAX_METADATA_BYTES = 2 * 1024 * 1024;
+
+// Allow the JSON envelope ({"body": <escaped metadata>}) for a 2 MB payload
+// through Next's body parser; oversized abuse is still rejected below with a
+// structured error rather than Next's opaque default.
+export const config = { api: { bodyParser: { sizeLimit: "6mb" } } };
+
+function fail(res: NextApiResponse, status: number, reason: string, details: string) {
+  res.status(status).json({ error: { reason, details } });
+}
+
+function safeParse(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return undefined;
+  }
+}
+
+// Soft same-origin gate: blocks browser cross-origin use and trivial/CSRF-style
+// abuse of this credential-bearing endpoint. NOT strong auth — a non-browser
+// client can forge these headers; the size cap bounds per-request damage, and
+// real auth/rate-limiting is a deliberately deferred, separately-scoped step.
+function isSameOrigin(req: NextApiRequest): boolean {
+  const host = req.headers.host;
+  const source = req.headers.origin ?? req.headers.referer;
+  if (!host || !source) return false;
+  try {
+    return new URL(source).host === host;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Server-side proxy for pinning proposal metadata to Pinata.
+ *
+ * The Pinata credential (PINATA_JWT) is a server-only secret and is never
+ * exposed to the browser. The client posts the metadata string here; this
+ * route attaches the credential and forwards the pin request to Pinata,
+ * relaying Pinata's status and body back. Upstream failures (unreachable or
+ * non-JSON) are normalized to the same { error: { reason, details } } shape
+ * the client surfaces via formatPinataError.
+ */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "POST") {
+    fail(res, 405, "METHOD_NOT_ALLOWED", "Use POST");
+    return;
+  }
+
+  if (!isSameOrigin(req)) {
+    fail(res, 403, "FORBIDDEN", "Cross-origin requests are not allowed");
+    return;
+  }
+
+  const jwt = process.env.PINATA_JWT;
+  if (!jwt) {
+    fail(res, 500, "CONFIG_ERROR", "PINATA_JWT is not configured on the server");
+    return;
+  }
+
+  const parsed: unknown = typeof req.body === "string" ? safeParse(req.body) : req.body;
+  const strBody =
+    parsed && typeof parsed === "object" && "body" in parsed && typeof (parsed as { body: unknown }).body === "string"
+      ? (parsed as { body: string }).body
+      : undefined;
+  if (strBody === undefined) {
+    fail(res, 400, "BAD_REQUEST", "Expected JSON { body: string }");
+    return;
+  }
+
+  if (Buffer.byteLength(strBody, "utf8") > MAX_METADATA_BYTES) {
+    fail(res, 413, "PAYLOAD_TOO_LARGE", `Metadata exceeds the ${MAX_METADATA_BYTES}-byte limit`);
+    return;
+  }
+
+  const form = new FormData();
+  // Use Blob + the filename argument rather than `File`, which is only a
+  // global on Node >= 20; the deployment runtime is not pinned here.
+  form.append("file", new Blob([strBody], { type: "text/plain" }), UPLOAD_FILE_NAME);
+  form.append("pinataMetadata", JSON.stringify({ name: UPLOAD_FILE_NAME }));
+  form.append("pinataOptions", JSON.stringify({ cidVersion: 1 }));
+
+  let pinataRes: Response;
+  try {
+    pinataRes = await fetch(PINATA_PIN_FILE_URL, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${jwt}` },
+      body: form,
+    });
+  } catch (e) {
+    fail(res, 502, "UPSTREAM_ERROR", e instanceof Error ? e.message : "Could not reach Pinata");
+    return;
+  }
+
+  // Relay Pinata's status and JSON body so the client keeps surfacing the
+  // real reason (e.g. plan-usage block) via formatPinataError. A non-JSON
+  // upstream response is normalized into the same structured error shape.
+  const data = await pinataRes.json().catch(() => null);
+  if (data === null) {
+    const status = pinataRes.ok ? 502 : pinataRes.status;
+    fail(res, status, "BAD_GATEWAY", `Pinata returned a non-JSON response (HTTP ${pinataRes.status})`);
+    return;
+  }
+  res.status(pinataRes.status).json(data);
+}

--- a/packages/ui/src/tests/api-pin.test.ts
+++ b/packages/ui/src/tests/api-pin.test.ts
@@ -1,0 +1,172 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import handler from "../pages/api/pin";
+
+type MockRes = {
+  statusCode: number;
+  body: unknown;
+  status: (code: number) => MockRes;
+  json: (payload: unknown) => MockRes;
+};
+
+function mockRes(): MockRes {
+  return {
+    statusCode: 200,
+    body: undefined,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+const HOST = "dao.test";
+
+type ReqInit = { method?: string; headers?: Record<string, string>; body?: unknown };
+
+// Same-origin browser request by default; tests override what they exercise.
+function mockReq(init: ReqInit = {}) {
+  return {
+    method: init.method ?? "POST",
+    headers: { host: HOST, origin: `https://${HOST}`, ...(init.headers ?? {}) },
+    body: init.body !== undefined ? init.body : { body: "{}" },
+  };
+}
+
+type Handler = typeof handler;
+const call = (req: unknown, res: MockRes) =>
+  handler(req as Parameters<Handler>[0], res as unknown as Parameters<Handler>[1]);
+
+describe("/api/pin", () => {
+  const originalFetch = globalThis.fetch;
+  const originalJwt = process.env.PINATA_JWT;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    if (originalJwt === undefined) delete process.env.PINATA_JWT;
+    else process.env.PINATA_JWT = originalJwt;
+  });
+
+  test("attaches the server-only JWT and relays the Pinata CID", async () => {
+    process.env.PINATA_JWT = "server-secret-jwt";
+    let pinataUrl = "";
+    let pinataAuth = "";
+    let sentBody: unknown;
+    globalThis.fetch = (async (input: unknown, init: RequestInit) => {
+      pinataUrl = typeof input === "string" ? input : ((input as Request)?.url ?? "");
+      pinataAuth = new Headers(init?.headers).get("authorization") ?? "";
+      sentBody = init?.body;
+      return new Response(JSON.stringify({ IpfsHash: "bafyServer" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+
+    const res = mockRes();
+    await call(mockReq({ body: { body: JSON.stringify({ title: "x" }) } }), res);
+
+    expect(pinataUrl).toBe("https://api.pinata.cloud/pinning/pinFileToIPFS");
+    expect(pinataAuth).toBe("Bearer server-secret-jwt");
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ IpfsHash: "bafyServer" });
+    // Multipart contract: a file part is sent (no reliance on global `File`)
+    expect(sentBody).toBeInstanceOf(FormData);
+    const form = sentBody as FormData;
+    expect(form.get("file")).toBeInstanceOf(Blob);
+    expect(String(form.get("pinataMetadata"))).toContain("taiko.json");
+  });
+
+  test("relays Pinata error status and body unchanged", async () => {
+    process.env.PINATA_JWT = "server-secret-jwt";
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          error: { reason: "FORBIDDEN", details: "Account blocked due to plan usage limit" },
+        }),
+        { status: 403, headers: { "content-type": "application/json" } }
+      )) as unknown as typeof fetch;
+
+    const res = mockRes();
+    await call(mockReq(), res);
+
+    expect(res.statusCode).toBe(403);
+    expect(res.body).toEqual({
+      error: { reason: "FORBIDDEN", details: "Account blocked due to plan usage limit" },
+    });
+  });
+
+  test("rejects non-POST requests", async () => {
+    const res = mockRes();
+    await call(mockReq({ method: "GET" }), res);
+    expect(res.statusCode).toBe(405);
+  });
+
+  test("rejects cross-origin requests", async () => {
+    process.env.PINATA_JWT = "server-secret-jwt";
+    const res = mockRes();
+    await call(mockReq({ headers: { origin: "https://evil.example" } }), res);
+    expect(res.statusCode).toBe(403);
+    expect((res.body as { error: { reason: string } }).error.reason).toBe("FORBIDDEN");
+  });
+
+  test("rejects requests with no Origin or Referer", async () => {
+    process.env.PINATA_JWT = "server-secret-jwt";
+    const res = mockRes();
+    await call({ method: "POST", headers: { host: HOST }, body: { body: "{}" } }, res);
+    expect(res.statusCode).toBe(403);
+  });
+
+  test("fails clearly when PINATA_JWT is not configured", async () => {
+    delete process.env.PINATA_JWT;
+    const res = mockRes();
+    await call(mockReq(), res);
+    expect(res.statusCode).toBe(500);
+  });
+
+  test("rejects a malformed request body", async () => {
+    process.env.PINATA_JWT = "server-secret-jwt";
+    const res = mockRes();
+    await call(mockReq({ body: {} }), res);
+    expect(res.statusCode).toBe(400);
+  });
+
+  test("rejects metadata larger than the size cap", async () => {
+    process.env.PINATA_JWT = "server-secret-jwt";
+    const huge = "a".repeat(2 * 1024 * 1024 + 1);
+    const res = mockRes();
+    await call(mockReq({ body: { body: huge } }), res);
+    expect(res.statusCode).toBe(413);
+    expect((res.body as { error: { reason: string } }).error.reason).toBe("PAYLOAD_TOO_LARGE");
+  });
+
+  test("returns a structured error when Pinata is unreachable", async () => {
+    process.env.PINATA_JWT = "server-secret-jwt";
+    globalThis.fetch = (async () => {
+      throw new Error("network down");
+    }) as unknown as typeof fetch;
+
+    const res = mockRes();
+    await call(mockReq(), res);
+
+    expect(res.statusCode).toBe(502);
+    expect((res.body as { error: { reason: string } }).error.reason).toBe("UPSTREAM_ERROR");
+  });
+
+  test("returns a structured error when Pinata responds with non-JSON", async () => {
+    process.env.PINATA_JWT = "server-secret-jwt";
+    globalThis.fetch = (async () =>
+      new Response("<html>502 Bad Gateway</html>", {
+        status: 502,
+        headers: { "content-type": "text/html" },
+      })) as unknown as typeof fetch;
+
+    const res = mockRes();
+    await call(mockReq(), res);
+
+    expect(res.statusCode).toBe(502);
+    expect((res.body as { error: { reason: string } }).error.reason).toBe("BAD_GATEWAY");
+  });
+});

--- a/packages/ui/src/tests/ipfs.test.ts
+++ b/packages/ui/src/tests/ipfs.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { uploadToPinata } from "../utils/ipfs";
+
+describe("uploadToPinata", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("surfaces structured Pinata error details", async () => {
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          error: {
+            reason: "FORBIDDEN",
+            details: "Account blocked due to plan usage limit",
+          },
+        }),
+        {
+          status: 403,
+          headers: { "content-type": "application/json" },
+        }
+      )) as unknown as typeof fetch;
+
+    await expect(uploadToPinata(JSON.stringify({ title: "Enable Raiko2 on mainnet" }))).rejects.toThrow(
+      "Pinata upload failed (403): FORBIDDEN - Account blocked due to plan usage limit"
+    );
+  });
+
+  test("uploads via the same-origin /api/pin proxy without exposing credentials", async () => {
+    let calledUrl: string | undefined;
+    let calledInit: RequestInit | undefined;
+    globalThis.fetch = (async (input: unknown, init: RequestInit) => {
+      calledUrl = typeof input === "string" ? input : (input as Request)?.url;
+      calledInit = init;
+      return new Response(JSON.stringify({ IpfsHash: "bafytest123" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const uri = await uploadToPinata(JSON.stringify({ title: "Enable Raiko2 on mainnet" }));
+
+    expect(uri).toBe("ipfs://bafytest123");
+    expect(calledUrl).toBe("/api/pin/");
+    expect(calledInit?.method).toBe("POST");
+    // The browser must never carry a Pinata credential
+    const headers = new Headers(calledInit?.headers);
+    expect(headers.get("authorization")).toBeNull();
+  });
+});

--- a/packages/ui/src/utils/ipfs.ts
+++ b/packages/ui/src/utils/ipfs.ts
@@ -1,11 +1,10 @@
-import { PUB_IPFS_ENDPOINTS, PUB_PINATA_JWT, PUB_APP_NAME } from "@/constants";
+import { PUB_IPFS_ENDPOINTS } from "@/constants";
 import { Hex, fromHex, toBytes } from "viem";
 import { CID } from "multiformats/cid";
 import * as raw from "multiformats/codecs/raw";
 import { sha256 } from "multiformats/hashes/sha2";
 
 const IPFS_FETCH_TIMEOUT = 1000; // 1 second
-const UPLOAD_FILE_NAME = PUB_APP_NAME.toLowerCase().trim().replaceAll(" ", "-") + ".json";
 
 export function fetchIpfsAsJson(ipfsUri: string) {
   return fetchRawIpfs(ipfsUri).then((res) => res.json());
@@ -20,24 +19,20 @@ export function fetchIpfsAsBlob(ipfsUri: string) {
 }
 
 export async function uploadToPinata(strBody: string) {
-  const blob = new Blob([strBody], { type: "text/plain" });
-  const file = new File([blob], UPLOAD_FILE_NAME);
-  const data = new FormData();
-  data.append("file", file);
-  data.append("pinataMetadata", JSON.stringify({ name: UPLOAD_FILE_NAME }));
-  data.append("pinataOptions", JSON.stringify({ cidVersion: 1 }));
-
-  const res = await fetch("https://api.pinata.cloud/pinning/pinFileToIPFS", {
+  // The Pinata credential is server-only. The browser talks to our own
+  // same-origin proxy (/api/pin), which attaches the secret and forwards
+  // the pin request to Pinata. See src/pages/api/pin.ts.
+  const res = await fetch("/api/pin/", {
     method: "POST",
     headers: {
-      Authorization: `Bearer ${PUB_PINATA_JWT}`,
+      "Content-Type": "application/json",
     },
-    body: data,
+    body: JSON.stringify({ body: strBody }),
   });
 
   const resData = await res.json();
 
-  if (resData.error) throw new Error("Request failed: " + resData.error);
+  if (resData.error || !res.ok) throw new Error(`Pinata upload failed (${res.status}): ${formatPinataError(resData)}`);
   else if (!resData.IpfsHash) throw new Error("Could not pin the metadata");
   return "ipfs://" + resData.IpfsHash;
 }
@@ -84,4 +79,17 @@ async function fetchRawIpfs(ipfsUri: string): Promise<Response> {
 function resolvePath(uri: string) {
   const path = uri.includes("ipfs://") ? uri.substring(7) : uri;
   return path;
+}
+
+function formatPinataError(resData: unknown) {
+  if (!resData || typeof resData !== "object") return "Unknown error";
+
+  const error = "error" in resData ? resData.error : resData;
+  if (typeof error === "string") return error;
+  if (!error || typeof error !== "object") return "Unknown error";
+
+  const reason = "reason" in error && typeof error.reason === "string" ? error.reason : "";
+  const details = "details" in error && typeof error.details === "string" ? error.details : "";
+  const message = "message" in error && typeof error.message === "string" ? error.message : "";
+  return [reason, details || message].filter(Boolean).join(" - ") || "Unknown error";
 }


### PR DESCRIPTION
Pinata uploads were using a public env var, which would inline the JWT into the browser bundle. This moves proposal metadata pins through a same-origin API route so the credential stays server-side, adds a metadata size cap, and keeps the existing proposal/delegation upload call sites unchanged. Deployments need the server env var set as PINATA_JWT instead of NEXT_PUBLIC_PINATA_JWT.