### PR TITLE
fix(dao-ui): guard proposal execution when wallet is disconnected

### DIFF
--- a/packages/ui/src/plugins/emergency-multisig/hooks/useProposalExecute.tsx
+++ b/packages/ui/src/plugins/emergency-multisig/hooks/useProposalExecute.tsx
@@ -45,6 +45,13 @@ export function useProposalExecute(proposalId: string) {
   const executeProposal = () => {
     let actualMetadataUri: string;
 
+    if (!isConnected) {
+      addAlert(CONNECT_WALLET_EXECUTE_ALERT_MESSAGE, {
+        type: "error",
+        description: CONNECT_WALLET_EXECUTE_ALERT_DESCRIPTION,
+      });
+      return;
+    }
     if (!canExecute) return;
     if (!privateRawMetadata || !proposal?.actions) return;
 

--- a/packages/ui/src/plugins/multisig/hooks/useProposalExecute.tsx
+++ b/packages/ui/src/plugins/multisig/hooks/useProposalExecute.tsx
@@ -36,6 +36,13 @@ export function useProposalExecute(proposalId: string) {
   const { isLoading: isConfirming, isSuccess: isConfirmed } = useWaitForTransactionReceipt({ hash: executeTxHash });
 
   const executeProposal = () => {
+    if (!isConnected) {
+      addAlert(CONNECT_WALLET_EXECUTE_ALERT_MESSAGE, {
+        type: "error",
+        description: CONNECT_WALLET_EXECUTE_ALERT_DESCRIPTION,
+      });
+      return;
+    }
     if (!canExecute) return;
 
     setIsExecuting(true);

--- a/packages/ui/src/plugins/optimistic-proposals/hooks/useProposalExecute.tsx
+++ b/packages/ui/src/plugins/optimistic-proposals/hooks/useProposalExecute.tsx
@@ -38,6 +38,13 @@ export function useProposalExecute(index: number) {
   const { isLoading: isConfirming, isSuccess: isConfirmed } = useWaitForTransactionReceipt({ hash: executeTxHash });
 
   const executeProposal = () => {
+    if (!isConnected) {
+      addAlert(CONNECT_WALLET_EXECUTE_ALERT_MESSAGE, {
+        type: "error",
+        description: CONNECT_WALLET_EXECUTE_ALERT_DESCRIPTION,
+      });
+      return;
+    }
     if (!canExecute) return;
     if (typeof proposalId === "undefined") return;
 


### PR DESCRIPTION
## summary
- restore explicit disconnected-wallet guards inside all proposal execute hooks
- keep page-level connect wallet UX intact while making the hook safe as an API boundary

## validation
- pnpm --filter dao-ui lint
- pnpm --filter dao-ui build